### PR TITLE
chore: update OEP-65 to Under Review

### DIFF
--- a/oeps/architectural-decisions/oep-0065-frontend-composability.rst
+++ b/oeps/architectural-decisions/oep-0065-frontend-composability.rst
@@ -9,7 +9,7 @@ OEP-65: Frontend Composability
    * - Title
      - Frontend Composability
    * - Last Modified
-     - 2024-04-03
+     - 2024-04-12
    * - Authors
      -
        * Adolfo R. Brandes <adolfo@axim.org>
@@ -18,13 +18,13 @@ OEP-65: Frontend Composability
    * - Arbiter
      - Adam Stankiewicz <astankiewicz@2u.com>
    * - Status
-     - Draft
+     - Under Review
    * - Type
      - Architecture
    * - Created
      - 2024-04-03
    * - Review Period
-     - <start - target end dates for review>
+     - April 15, 2024 - April 29, 2024
    * - Resolution
      - <links to any discussions where the final status was decided>
    * - References
@@ -479,3 +479,8 @@ Change History
 
 * Adding references to the discovery projects for this OEP: FC-0054 and FC-0007.
 * Adding a diagram of the proposed MFE architecture.
+
+2024-04-12
+==========
+
+* Updates the OEP-65 status from "Draft" to "Under Review" and set a 2-week review period from April 15, 2024 - April 29, 2024.


### PR DESCRIPTION
Updates the status of the OEP-65 to "Under Review", with a review period of April 15, 2024 - April 29, 2024.